### PR TITLE
Fix silent fails due to chunked transfer encoding problems.

### DIFF
--- a/lib/Doctrine/CouchDB/HTTP/SocketClient.php
+++ b/lib/Doctrine/CouchDB/HTTP/SocketClient.php
@@ -293,9 +293,6 @@ class SocketClient extends AbstractHTTPClient
                     }
                 }
             } while ($bytesToRead > 0);
-
-            // Chop off \r\n from the end.
-            $body = substr($body, 0, -2);
         }
 
         // Reset the connection if the server asks for it.


### PR DESCRIPTION
After some debugging I figured that transfer-encoding chunked connections broke replication.

This happened with a web-server being traefik -> varnish -> nginx, but given #4 is already open it's probably not specific to the web-server's used. It works locally with a plain Apache without this fix though.

Anyway, #4 did not resolve the issue for me, but this PR does. I don't know why it should be necessary to chop off \r\n - it seems it's not.